### PR TITLE
feat: add S3 backend for Terraform state

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,12 @@
 terraform {
   required_version = ">= 1.0"
+  
+  backend "s3" {
+    bucket = "nimby-shapetopoi-terraform-state-1756463076"
+    key    = "terraform.tfstate"
+    region = "us-west-2"
+  }
+  
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,10 +2,9 @@ terraform {
   required_version = ">= 1.0"
   
   backend "s3" {
-    bucket         = "nimby-shapetopoi-terraform-state-1756463076"
-    key            = "terraform.tfstate"
-    region         = "us-west-2"
-    dynamodb_table = "nimby-shapetopoi-terraform-locks"
+    bucket = "nimby-shapetopoi-terraform-state-1756463076"
+    key    = "terraform.tfstate"
+    region = "us-west-2"
   }
   
   required_providers {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,9 +2,10 @@ terraform {
   required_version = ">= 1.0"
   
   backend "s3" {
-    bucket = "nimby-shapetopoi-terraform-state-1756463076"
-    key    = "terraform.tfstate"
-    region = "us-west-2"
+    bucket         = "nimby-shapetopoi-terraform-state-1756463076"
+    key            = "terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "nimby-shapetopoi-terraform-locks"
   }
   
   required_providers {


### PR DESCRIPTION
- Configure S3 backend to share state between local and GitHub Actions
- Use bucket nimby-shapetopoi-terraform-state-1756463076 for state storage
- Resolves state synchronization issues between environments