### PR TITLE
fix: optimize POI limit warning for dark mode

### DIFF
--- a/internal/server/templates/result.templ
+++ b/internal/server/templates/result.templ
@@ -10,7 +10,7 @@ templ ConversionResult(modName string, poiCount int, downloadPath string, previe
 			Successfully generated <strong>{ modName }</strong> with <strong>{ fmt.Sprintf("%d", poiCount) }</strong> POIs.
 		</p>
 		if len(groups) > 1 {
-			<div class="card" style="background-color: #fff3cd; border-color: #ffc107; margin: 16px 0">
+			<div class="warning">
 				<p style="margin: 0">
 					<strong>⚠️ POI Limit Exceeded:</strong> Your data contains more than 10,000 POIs. 
 					The mod has been split into { fmt.Sprintf("%d", len(groups)) } separate mods to comply with NIMBY Rails' 10k POI limit per mod.

--- a/internal/server/templates/result_templ.go
+++ b/internal/server/templates/result_templ.go
@@ -63,7 +63,7 @@ func ConversionResult(modName string, poiCount int, downloadPath string, preview
 			return templ_7745c5c3_Err
 		}
 		if len(groups) > 1 {
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"card\" style=\"background-color: #fff3cd; border-color: #ffc107; margin: 16px 0\"><p style=\"margin: 0\"><strong>⚠️ POI Limit Exceeded:</strong> Your data contains more than 10,000 POIs.  The mod has been split into ")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString("<div class=\"warning\"><p style=\"margin: 0\"><strong>⚠️ POI Limit Exceeded:</strong> Your data contains more than 10,000 POIs.  The mod has been split into ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -19,6 +19,9 @@
     --success-bg: #d1fae5;
     --success-border: #a7f3d0;
     --success-text: #059669;
+    --warning-bg: #fff3cd;
+    --warning-border: #ffc107;
+    --warning-text: #856404;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -43,6 +46,9 @@
         --success-bg: #052e16;
         --success-border: #059669;
         --success-text: #86efac;
+        --warning-bg: #451a03;
+        --warning-border: #d97706;
+        --warning-text: #fbbf24;
     }
 }
 
@@ -242,6 +248,15 @@ body {
     border-radius: 8px;
     border: 1px solid var(--success-border);
     margin: 10px 0;
+}
+
+.warning {
+    color: var(--warning-text);
+    background: var(--warning-bg);
+    padding: 12px 16px;
+    border-radius: 8px;
+    border: 1px solid var(--warning-border);
+    margin: 16px 0;
 }
 
 .map-preview {


### PR DESCRIPTION
- Add warning color variables for light and dark themes
- Create .warning CSS class with proper dark mode support
- Replace inline styles with CSS class in POI limit warning
- Warning now adapts automatically to user's theme preference