### PR TITLE
feat: increase ECS task resources for better performance

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -289,8 +289,8 @@ resource "aws_ecs_task_definition" "app" {
   family                   = var.app_name
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
-  cpu                     = "512"
-  memory                  = "1024"
+  cpu                     = "2048"
+  memory                  = "4096"
   execution_role_arn      = aws_iam_role.ecs_task_execution_role.arn
   task_role_arn           = aws_iam_role.ecs_task_role.arn
 


### PR DESCRIPTION
- Increase CPU from 512 to 2048 units (2 vCPUs)
- Increase memory from 1024 to 4096 MB (4GB)
- Should significantly improve file processing speed and overall responsiveness