### PR TITLE
feat: improve KML placemark support with larger fonts

### DIFF
--- a/cmd/nimby_shapetopoi/main_test.go
+++ b/cmd/nimby_shapetopoi/main_test.go
@@ -101,8 +101,8 @@ func TestProcessInputFilesIndividually(t *testing.T) {
 			if poi.Lon != 10.0 || poi.Lat != 53.0 {
 				t.Errorf("Expected coordinates (10.0, 53.0), got (%f, %f)", poi.Lon, poi.Lat)
 			}
-			if poi.Text != "" {
-				t.Errorf("Expected empty text, got '%s'", poi.Text)
+			if poi.Text != "Test Point" {
+				t.Errorf("Expected text 'Test Point', got '%s'", poi.Text)
 			}
 		}
 	}
@@ -304,8 +304,8 @@ func TestMainWorkflow_Integration(t *testing.T) {
 
 		if len(entry.POIList) > 0 {
 			firstPOI := entry.POIList[0]
-			if firstPOI.Text != "" {
-				t.Errorf("Expected empty text, got '%s'", firstPOI.Text)
+			if firstPOI.Text != "Integration Test Point" {
+				t.Errorf("Expected text 'Integration Test Point', got '%s'", firstPOI.Text)
 			}
 			if firstPOI.Lon != 11.123 || firstPOI.Lat != 54.456 {
 				t.Errorf("Expected first POI coordinates (11.123, 54.456), got (%f, %f)",

--- a/internal/geometry/interface.go
+++ b/internal/geometry/interface.go
@@ -12,6 +12,7 @@ import (
 const (
 	defaultColor      = "0000ff"
 	defaultFontSize   = 12
+	placemarkFontSize = 16 // Larger font for placemark names
 	defaultMaxLod     = 10
 	defaultDemand     = ""
 	defaultPopulation = 0

--- a/internal/geometry/kml.go
+++ b/internal/geometry/kml.go
@@ -79,7 +79,7 @@ func (k *KMLReader) resolveColor(overrideColor string, placemark *kml.Placemark,
 func (k *KMLReader) processPlacemark(placemark *kml.Placemark, document *kml.Document, poiList *poi.List, maxLod int32, color string) {
 	if placemark.Point != nil {
 		actualColor := k.resolveColor(color, placemark, document, "Point")
-		k.processPoint(placemark.Point, poiList, maxLod, actualColor)
+		k.processPoint(placemark.Point, placemark.Name, poiList, maxLod, actualColor)
 	}
 	if placemark.LineString != nil {
 		actualColor := k.resolveColor(color, placemark, document, "LineString")
@@ -98,7 +98,7 @@ func (k *KMLReader) processPlacemark(placemark *kml.Placemark, document *kml.Doc
 	}
 }
 
-func (k *KMLReader) processPoint(point *kml.Point, poiList *poi.List, maxLod int32, color string) {
+func (k *KMLReader) processPoint(point *kml.Point, placemarkName string, poiList *poi.List, maxLod int32, color string) {
 	coords, err := kml.ParseCoordinates(point.Coordinates)
 	if err != nil {
 		return
@@ -109,12 +109,17 @@ func (k *KMLReader) processPoint(point *kml.Point, poiList *poi.List, maxLod int
 	}
 
 	for _, coord := range coords {
+		fontSize := int32(defaultFontSize)
+		if placemarkName != "" {
+			fontSize = int32(placemarkFontSize) // Use larger font for placemark names
+		}
+
 		p := poi.POI{
 			Lon:         coord.Lon,
 			Lat:         coord.Lat,
 			Color:       color,
-			Text:        "",
-			FontSize:    defaultFontSize,
+			Text:        placemarkName, // Use placemark name for individual points
+			FontSize:    fontSize,
 			MaxLod:      maxLod,
 			Transparent: false,
 			Demand:      defaultDemand,
@@ -222,7 +227,7 @@ func (k *KMLReader) processPolygon(polygon *kml.Polygon, poiList *poi.List, maxL
 func (k *KMLReader) processMultiGeometry(multiGeometry *kml.MultiGeometry, document *kml.Document, placemark *kml.Placemark, poiList *poi.List, maxLod int32, color string) {
 	for _, point := range multiGeometry.Points {
 		actualColor := k.resolveColor(color, placemark, document, "Point")
-		k.processPoint(&point, poiList, maxLod, actualColor)
+		k.processPoint(&point, placemark.Name, poiList, maxLod, actualColor)
 	}
 	for _, lineString := range multiGeometry.LineStrings {
 		actualColor := k.resolveColor(color, placemark, document, "LineString")

--- a/internal/geometry/kml_test.go
+++ b/internal/geometry/kml_test.go
@@ -52,8 +52,8 @@ func TestKMLReader_ParseFile_SimpleKML(t *testing.T) {
 	if pointPOI.Lon != 10.123 || pointPOI.Lat != 53.456 {
 		t.Errorf("Expected point coordinates (10.123, 53.456), got (%f, %f)", pointPOI.Lon, pointPOI.Lat)
 	}
-	if pointPOI.Text != "" {
-		t.Errorf("Expected empty text, got '%s'", pointPOI.Text)
+	if pointPOI.Text != "Test Point" {
+		t.Errorf("Expected text 'Test Point', got '%s'", pointPOI.Text)
 	}
 	if pointPOI.Color != "0000ff" {
 		t.Errorf("Expected point color '0000ff', got '%s'", pointPOI.Color)
@@ -64,8 +64,9 @@ func TestKMLReader_ParseFile_SimpleKML(t *testing.T) {
 	if linePointPOI.Color != "0000ff" {
 		t.Errorf("Expected line point color '0000ff', got '%s'", linePointPOI.Color)
 	}
+	// Line points should not have text on every point
 	if linePointPOI.Text != "" {
-		t.Errorf("Expected empty text, got '%s'", linePointPOI.Text)
+		t.Errorf("Expected empty text for line point, got '%s'", linePointPOI.Text)
 	}
 }
 
@@ -140,10 +141,15 @@ func TestKMLReader_ParseFile_MultiGeometry(t *testing.T) {
 		t.Errorf("Expected 3 POIs, got %d", len(*poiList))
 	}
 
-	// All should have the same text from placemark
-	for i, p := range *poiList {
-		if p.Text != "" {
-			t.Errorf("POI %d: Expected empty text, got '%s'", i, p.Text)
+	// First POI is a Point, should have the placemark name
+	if (*poiList)[0].Text != "Multi Test" {
+		t.Errorf("POI 0: Expected text 'Multi Test', got '%s'", (*poiList)[0].Text)
+	}
+
+	// Next POIs are from LineString, should not have text on each point
+	for i := 1; i < len(*poiList); i++ {
+		if (*poiList)[i].Text != "" {
+			t.Errorf("POI %d: Expected empty text for line point, got '%s'", i, (*poiList)[i].Text)
 		}
 	}
 }
@@ -216,10 +222,10 @@ func TestKMLReader_ParseFile_ExtendedData(t *testing.T) {
 		t.Errorf("Expected 1 POI, got %d", len(*poiList))
 	}
 
-	// Should use the Label from ExtendedData instead of name
+	// Point should have the placemark name
 	p := (*poiList)[0]
-	if p.Text != "" {
-		t.Errorf("Expected empty text, got '%s'", p.Text)
+	if p.Text != "Test Point" {
+		t.Errorf("Expected text 'Test Point', got '%s'", p.Text)
 	}
 }
 


### PR DESCRIPTION
- Add placemark names as text for Point geometries
- Use larger font size (16) for placemark names vs default (12)
- Path geometries continue to use interval-based labeling
- Update tests to reflect new placemark text behavior