### PR TITLE
feat: add comprehensive inline KML style support

### DIFF
--- a/internal/geometry/kml.go
+++ b/internal/geometry/kml.go
@@ -15,7 +15,7 @@ func (k *KMLReader) ParseFile(filePath string) (*poi.List, error) {
 }
 
 func (k *KMLReader) ParseFileWithConfig(filePath string, maxLod int32) (*poi.List, error) {
-	return k.ParseFileWithFullConfig(filePath, maxLod, defaultColor)
+	return k.ParseFileWithFullConfig(filePath, maxLod, "")
 }
 
 func (k *KMLReader) ParseFileWithFullConfig(filePath string, maxLod int32, color string) (*poi.List, error) {
@@ -251,7 +251,8 @@ func (k *KMLReader) processMultiGeometry(multiGeometry *kml.MultiGeometry, docum
 func (k *KMLReader) getColorForGeometry(placemark *kml.Placemark, document *kml.Document, geometryType string) string {
 	// Try to get color from placemark style
 	if style := document.GetStyleForPlacemark(placemark); style != nil {
-		return kml.GetColorFromStyle(style, geometryType)
+		color := kml.GetColorFromStyle(style, geometryType)
+		return color
 	}
 
 	// Return empty string if no color found

--- a/internal/geometry/kml_test.go
+++ b/internal/geometry/kml_test.go
@@ -229,6 +229,62 @@ func TestKMLReader_ParseFile_ExtendedData(t *testing.T) {
 	}
 }
 
+func TestKMLReader_ParseFile_InlineStyle(t *testing.T) {
+	reader := &KMLReader{}
+	poiList, err := reader.ParseFile("../../testdata/sketch.kml")
+
+	if err != nil {
+		t.Fatalf("ParseFile returned error: %v", err)
+	}
+
+	if len(*poiList) == 0 {
+		t.Fatal("Expected POIs from sketch.kml, got 0")
+	}
+
+	// Check that inline LineStyle colors were extracted correctly
+	// ff33ccff (KML: aabbggrr) -> ffcc33 (NIMBY: rrggbb)
+	expectedColor := "ffcc33"
+
+	expectedColorCount := 0
+	defaultColorCount := 0
+	colorCounts := make(map[string]int)
+
+	for _, p := range *poiList {
+		colorCounts[p.Color]++
+		switch p.Color {
+		case expectedColor:
+			expectedColorCount++
+		case "0000ff": // default color
+			defaultColorCount++
+		}
+	}
+
+	t.Logf("Total POIs: %d", len(*poiList))
+	t.Logf("POIs with expected LineString color (%s): %d", expectedColor, expectedColorCount)
+	t.Logf("POIs with default color (0000ff): %d", defaultColorCount)
+
+	// Show all colors found
+	t.Logf("All colors found:")
+	for color, count := range colorCounts {
+		t.Logf("  %s: %d", color, count)
+	}
+
+	// Verify inline styles are working
+	if expectedColorCount == 0 {
+		t.Errorf("Expected some POIs with LineString color %s from inline styles, got 0", expectedColor)
+	}
+
+	// Should have no default color POIs when inline styles are present
+	if defaultColorCount > 0 {
+		t.Errorf("Expected no POIs with default color when inline styles are available, got %d", defaultColorCount)
+	}
+
+	// Should have multiple different colors from different inline styles
+	if len(colorCounts) < 2 {
+		t.Errorf("Expected multiple colors from different inline styles, got %d unique colors", len(colorCounts))
+	}
+}
+
 func TestKMLReader_ParseFile_Polygon(t *testing.T) {
 	kmlContent := `<?xml version="1.0" encoding="UTF-8"?>
 <kml xmlns="http://www.opengis.net/kml/2.2">

--- a/pkg/kml/kml.go
+++ b/pkg/kml/kml.go
@@ -37,6 +37,7 @@ type Placemark struct {
 	Name          string         `xml:"name"`
 	Description   string         `xml:"description"`
 	StyleURL      string         `xml:"styleUrl"`
+	Style         *Style         `xml:"Style"` // Support for inline styles
 	Point         *Point         `xml:"Point"`
 	LineString    *LineString    `xml:"LineString"`
 	LinearRing    *LinearRing    `xml:"LinearRing"`
@@ -100,10 +101,11 @@ type SimpleData struct {
 }
 
 type Style struct {
-	ID        string     `xml:"id,attr"`
-	IconStyle *IconStyle `xml:"IconStyle"`
-	LineStyle *LineStyle `xml:"LineStyle"`
-	PolyStyle *PolyStyle `xml:"PolyStyle"`
+	ID         string      `xml:"id,attr"`
+	IconStyle  *IconStyle  `xml:"IconStyle"`
+	LineStyle  *LineStyle  `xml:"LineStyle"`
+	PolyStyle  *PolyStyle  `xml:"PolyStyle"`
+	LabelStyle *LabelStyle `xml:"LabelStyle"`
 }
 
 type IconStyle struct {
@@ -125,6 +127,11 @@ type PolyStyle struct {
 	Color   string `xml:"color"`
 	Fill    int    `xml:"fill"`
 	Outline int    `xml:"outline"`
+}
+
+type LabelStyle struct {
+	Color string  `xml:"color"`
+	Scale float64 `xml:"scale"`
 }
 
 type StyleMap struct {
@@ -270,6 +277,12 @@ func (d *Document) GetStyleByID(styleID string) *Style {
 
 // GetStyleForPlacemark returns the appropriate style for a placemark
 func (d *Document) GetStyleForPlacemark(placemark *Placemark) *Style {
+	// First check for inline style
+	if placemark.Style != nil {
+		return placemark.Style
+	}
+
+	// Then check for styleUrl reference
 	if placemark.StyleURL == "" {
 		return nil
 	}
@@ -314,6 +327,11 @@ func GetColorFromStyle(style *Style, geometryType string) string {
 
 	switch geometryType {
 	case "Point":
+		// Check LabelStyle first for text color (commonly used for Point labels)
+		if style.LabelStyle != nil && style.LabelStyle.Color != "" {
+			return ConvertKMLColorToNimby(style.LabelStyle.Color)
+		}
+		// Fallback to IconStyle for icon color
 		if style.IconStyle != nil && style.IconStyle.Color != "" {
 			return ConvertKMLColorToNimby(style.IconStyle.Color)
 		}


### PR DESCRIPTION
- Add inline Style field to Placemark struct for direct style embedding
- Add LabelStyle support for Point text colors commonly used by third-party tools
- Update GetStyleForPlacemark to prioritize inline styles over styleUrl references
- Update GetColorFromStyle to check LabelStyle first for Points, then IconStyle
- Fix ParseFileWithConfig to allow style extraction instead of forcing default color
- Add comprehensive test using sketch.kml with both LineStyle and LabelStyle examples